### PR TITLE
CITY-15: Add "Invitation to an inclusive collaborative design activity"

### DIFF
--- a/ideas/invitation-to-collaborative-design/index.html
+++ b/ideas/invitation-to-collaborative-design/index.html
@@ -81,16 +81,17 @@
                         </li>
                         <li>Co-design session 2
                             <ul>
-                                <li>Hosted by Sidewalk Labs at 307 Lakeshore Boulevard East on Friday August 24th from 9:00 am - 5:00</li>
+                                <li>Hosted by Sidewalk Labs at 307 Lakeshore Boulevard East on Friday August 24th from 9:00 am - 5:00 pm.</li>
                             </ul>
                         </li>
                         <li>Co-design session 3
                             <ul>
-                                <li>This will be a split session hosted by OCAD University at 49 McCaul street on Wednesday September 5th and Thursday September 6th - 5:00 pm - 9:00 pm.</li>
+                                <li>This will be a split session hosted by OCAD University at 49 McCaul street on Wednesday September 5th and Thursday September 6th - 5:00 pm - 9:00 pm. Participants are asked to attend both evening sessions.</li>
                             </ul>
                         </li>
                     </ul>
 
+                    <p>Please email us back at <a href="mailto:cities@idrc.ocadu.ca">cities@idrc.ocadu.ca</a> if you are interested in joining.</p>
 
                     <p>We look forward to hearing from you.</p>
 

--- a/ideas/invitation-to-collaborative-design/index.html
+++ b/ideas/invitation-to-collaborative-design/index.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Co-designing Inclusive Cities - Invitation to an inclusive collaborative design activity</title>
+    <meta charset="utf-8">
+
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" type="text/css" href="../../js/lib/infusion/src/framework/preferences/css/Enactors.css" />
+    <link rel="stylesheet" type="text/css" href="../../js/lib/infusion/src/framework/preferences/css/PrefsEditor.css" />
+    <link rel="stylesheet" type="text/css" href="../../js/lib/infusion/src/framework/preferences/css/SeparatedPanelPrefsEditor.css" />
+    <script src="../../js/lib/infusion/infusion-custom.js"></script>
+    <link rel="stylesheet" href="../../css/style.css">
+</head>
+<body>
+
+    <!-- BEGIN markup for Preference Editor -->
+       <div class="flc-prefsEditor-separatedPanel fl-prefsEditor-separatedPanel">
+           <!--
+               This div is for the sliding panel bar that shows and hides the Preference Editor controls in the mobile view.
+               A separate panel bar for mobile displays is needed to preserver the correct tab order.
+           -->
+           <div class="fl-panelBar fl-panelBar-smallScreen">
+               <span class="fl-prefsEditor-buttons">
+                   <button class="flc-slidingPanel-toggleButton fl-prefsEditor-showHide"> Show/Hide</button>
+                   <button class="flc-prefsEditor-reset fl-prefsEditor-reset"><span class="fl-icon-undo"></span> Reset</button>
+               </span>
+           </div>
+
+           <!-- This is the div that will contain the Preference Editor component -->
+           <div class="flc-slidingPanel-panel flc-prefsEditor-iframe"></div>
+
+           <!--
+               This div is for the sliding panel bar that shows and hides the Preference Editor controls in the desktop view.
+               A separate panel bar for desktop displays is needed to preserver the correct tab order.
+           -->
+           <div class="fl-panelBar fl-panelBar-wideScreen">
+               <span class="fl-prefsEditor-buttons">
+                   <button class="flc-slidingPanel-toggleButton fl-prefsEditor-showHide"> Show/Hide</button>
+                   <button class="flc-prefsEditor-reset fl-prefsEditor-reset"><span class="fl-icon-undo"></span> Reset</button>
+               </span>
+           </div>
+       </div>
+       <!-- END markup for Preference Editor -->
+
+    <div id="body">
+
+        <div id="ideasHeader">
+
+            <div class="ideasHeaderContainer">
+                <div class="ideasHeaders"><h1><a href="/">Co-designing Inclusive Cities</a></h1>
+                <h2>Ideas in Progress</h2></div>
+                <div class="imageContainerIdeas"><img src="../../images/birds.png" class="img" alt="Birds" /></div>
+            </div>
+        </div>
+
+        <div id="ideasContent">
+
+            <div class="flc-toc-tocContainer toc"> </div>
+
+            <div class="ideasContentContainer">
+                <div class="ideasContentBlock">
+                    <span class="ideasDate">July 25, 2018</span>
+
+                    <h2>Invitation to an inclusive collaborative design activity</h2>
+
+                    <p>Dear Community,</p>
+
+                    <p><a href="https://idrc.ocadu.ca/">IDRC</a> has agreed to work with the <a href="https://sidewalktoronto.ca">Sidewalk Toronto</a> team to help with creation of their accessibility and inclusion principles. Sidewalk Toronto is a joint effort between Alphabet’s <a href="https://www.sidewalklabs.com/">Sidewalk Labs</a> and <a href="https://www.waterfrontoronto.ca/nbe/portal/waterfront/Home">Waterfront Toronto</a> to use smart technology and new construction techniques to develop a piece of land on Toronto’s eastern waterfront, beginning with the creation of the Quayside neighbourhood on Queen’s Quay East.</p>
+
+                    <p>We aim to ensure that the Sidewalk Toronto team considers the wide and diverse range of people’s needs and preferences in the design and development of this piece of land. We are reaching out to different groups and communities to invite them to participate in a co-design process in order to understand what they define and envision as an inclusive and accessible city. We can use this information to provide the Sidewalk Toronto team with recommendations regarding their accessibility and inclusion principles that will be included in their master innovation and development plan.</p>
+
+                    <p>We would like to invite you to join any of the following co-design events to contribute your ideas about creating an inclusive, welcoming, and livable city. Participants will receive $100 honoraria as a token of our appreciation for your participation and contribution. There is a total of 15-20 spots available per session. If you are interested in joining any of these events, please kindly email us back and we will be sure to secure a spot for you.</p>
+
+                    <p>Once we receive confirmation, we will send more background information for those attending. We plan to create an accessible experience throughout these sessions and we will provide accessibility services upon request.</p>
+
+                    <ul>
+                        <li>Co-design session 1
+                            <ul>
+                                <li>Hosted by OCAD university at 49 McCaul street on Wednesday, August 8th from 9am -5pm.</li>
+                            </ul>
+                        </li>
+                        <li>Co-design session 2
+                            <ul>
+                                <li>Hosted by Sidewalk Labs at 307 Lakeshore Boulevard East on Friday August 24th from 9:00 am - 5:00</li>
+                            </ul>
+                        </li>
+                        <li>Co-design session 3
+                            <ul>
+                                <li>This will be a split session hosted by OCAD University at 49 McCaul street on Wednesday September 5th and Thursday September 6th - 5:00 pm - 9:00 pm.</li>
+                            </ul>
+                        </li>
+                    </ul>
+
+
+                    <p>We look forward to hearing from you.</p>
+
+                    <p><a href="/" class="home">Back to home</a></p>
+                </div>
+            </div>
+        </div>
+
+        <div id="footer">
+            <div class="logoContainer">
+                <a href="http://idrc.ocadu.ca/" class="logo-idrc" title="Inclusive Design Research Centre">Inclusive Design Research Centre</a>
+            </div>
+            <p>This website is maintained and created by the <a href="https://idrc.ocadu.ca/">Inclusive Design Research Centre</a>.<br />
+                It is distributed under the <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode">Creative Commons Attribution, Non-Commercial, Share-Alike 4.0 International license</a>.</p>
+        </div>
+    </div>
+
+    <!-- Initialise UIO -->
+    <script>
+        $(document).ready(function () {
+            var uio = fluid.uiOptions.prefsEditor(".flc-prefsEditor-separatedPanel", {
+                terms: {
+                    "templatePrefix": "../../js/lib/infusion/src/framework/preferences/html",
+                    "messagePrefix": "../../js/lib/infusion/src/framework/preferences/messages"
+                },
+                "tocTemplate": "../../js/lib/infusion/src/components/tableOfContents/html/TableOfContents.html",
+                "ignoreForToC": {
+                    "overviewPanel": ".flc-overviewPanel"
+                }
+            });
+        });
+    </script>
+
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -91,18 +91,25 @@
 	<div id="ideasContainer">
 		<div class="ideas">
 			<h2>Ideas in Progress</h2>
+
+			<div class="ideasBlock">
+				<div class="ideasDate">July 25, 2018</div>
+				<div class="ideasLink"><h3><a href="ideas/invitation-to-collaborative-design">Invitation to an inclusive collaborative design activity</a></h3></div>
+				<div class="ideasDesc"><p>IDRC has agreed to work with the Sidewalk Toronto team to help with creation of their accessibility and inclusion principles. We would like to invite you to join a co-design process to contribute your ideas about creating an inclusive, welcoming, and livable city. <a href="ideas/invitation-to-collaborative-design">Read more</a>.</p></div>
+			</div>
+
 			<div class="ideasBlock">
 				<div class="ideasDate">June 25, 2018</div>
 				<div class="ideasLink"><h3><a href="ideas/students-co-design-activity">Students co-designing their dream neighbourhoods</a></h3></div>
 				<div class="ideasDesc"><p>The cities being built today are the cities our children will be living in as adults. However, children are seldom included in urban design and planning conversations and processes. <a href="ideas/students-co-design-activity">Read more</a>.</p></div>
 			</div>
-      
+
 			<div class="ideasBlock">
 				<div class="ideasDate">May 10, 2018</div>
 				<div class="ideasLink"><h3><a href="ideas/co-design-draft-proposal">IDRC Inclusive Co-Design Draft Proposal</a></h3></div>
 				<div class="ideasDesc"><p>Last week at their public roundtable meeting, Sidewalk Toronto announced a new partnership with OCAD University to address accessibility issues in their Quayside project. <a href="ideas/co-design-draft-proposal">Read more</a>.</p></div>
 			</div>
-			
+
 			<div class="ideasBlock">
 				<div class="ideasDate">May 8, 2018</div>
 				<div class="ideasLink"><h3><a href="ideas/for-an-inclusive-quayside">Ideas for an Inclusive Quayside</a></h3></div>


### PR DESCRIPTION
https://issues.fluidproject.org/browse/CITY-15

Some notes:

- For the summary on the front page, I used the following: "IDRC has agreed to work with the Sidewalk Toronto team to help with creation of their accessibility and inclusion principles. We would like to invite you to join a co-design process to contribute your ideas about creating an inclusive, welcoming, and livable city."
- I removed the text "To find more about our work please visit the Co-designing Inclusive Cities website" from the post text as it seemed redundant/self-referential
- I rendered the list of sessions in nested `<ul>`s
