### PR TITLE
CITY-27: Add backlinks to image description pages

### DIFF
--- a/content/hackathon/prd/ai-floor-describer.md
+++ b/content/hackathon/prd/ai-floor-describer.md
@@ -46,4 +46,4 @@ Auto-generate an audio description of a one-floor floorplan, including the eleva
 
 - Machine Learning
 
-[Back to the Hackathon project descriptions]({{< relref "/ideas/hackathon-project-descriptions.md" >}})
+{{< backlink "/ideas/hackathon-project-descriptions.md" >}}

--- a/content/hackathon/prd/audible-incoming-traffic-warnings.md
+++ b/content/hackathon/prd/audible-incoming-traffic-warnings.md
@@ -49,4 +49,4 @@ An occupancy sensor (pressure sensor, camera, etc.) in the street that lets peop
 
 - Arduino skills / sensors (some light hardware)
 
-[Back to the Hackathon project descriptions]({{< relref "/ideas/hackathon-project-descriptions.md" >}})
+{{< backlink "/ideas/hackathon-project-descriptions.md" >}}

--- a/content/hackathon/prd/augmented-reality-park-feedback.md
+++ b/content/hackathon/prd/augmented-reality-park-feedback.md
@@ -46,4 +46,4 @@ Providing actionable information about a public park — features and amenities 
 
 - Experience with AR programming
 
-[Back to the Hackathon project descriptions]({{< relref "/ideas/hackathon-project-descriptions.md" >}})
+{{< backlink "/ideas/hackathon-project-descriptions.md" >}}

--- a/content/hackathon/prd/construction-advisory-beacon-messages.md
+++ b/content/hackathon/prd/construction-advisory-beacon-messages.md
@@ -46,4 +46,4 @@ An advisory message sent from a beacon informing people of construction impedime
 - Machine learning
 - Programming
 
-[Back to the Hackathon project descriptions]({{< relref "/ideas/hackathon-project-descriptions.md" >}})
+{{< backlink "/ideas/hackathon-project-descriptions.md" >}}

--- a/content/hackathon/prd/rumble-pavement.md
+++ b/content/hackathon/prd/rumble-pavement.md
@@ -42,4 +42,4 @@ A dynamic audible/haptic indication of where the sidewalk (pedestrian-only secti
 - Hardware engineering (Raspberry Pi)
 - Programming
 
-[Back to the Hackathon project descriptions]({{< relref "/ideas/hackathon-project-descriptions.md" >}})
+{{< backlink "/ideas/hackathon-project-descriptions.md" >}}

--- a/content/hackathon/prd/self-driving-cars-for-sub-emergency-medical-visits.md
+++ b/content/hackathon/prd/self-driving-cars-for-sub-emergency-medical-visits.md
@@ -50,4 +50,4 @@ A dependable audio interface for ordering non-emergency medical transport.
 - Programming
 - UX flow design
 
-[Back to the Hackathon project descriptions]({{< relref "/ideas/hackathon-project-descriptions.md" >}})
+{{< backlink "/ideas/hackathon-project-descriptions.md" >}}

--- a/content/hackathon/prd/tactile-sidewalk-wayfinding-strip.md
+++ b/content/hackathon/prd/tactile-sidewalk-wayfinding-strip.md
@@ -51,4 +51,4 @@ A continuous tactile path on all sidewalks that provides wayfinding to and conte
 - Ability to cut, tape and glue
 - Ability to test with wheels
 
-[Back to the Hackathon project descriptions]({{< relref "/ideas/hackathon-project-descriptions.md" >}})
+{{< backlink "/ideas/hackathon-project-descriptions.md" >}}

--- a/content/hackathon/prd/tranquil-refuge.md
+++ b/content/hackathon/prd/tranquil-refuge.md
@@ -61,4 +61,4 @@ A place where people who need a physical or sensory reprieve from the environmen
 - Google Home conversational program (apps for Google Home)
 - Someone who can move blocks, wood and foam core around.
 
-[Back to the Hackathon project descriptions]({{< relref "/ideas/hackathon-project-descriptions.md" >}})
+{{< backlink "/ideas/hackathon-project-descriptions.md" >}}

--- a/content/image-descriptions/co-design-session-1/wishboard.md
+++ b/content/image-descriptions/co-design-session-1/wishboard.md
@@ -83,3 +83,5 @@ Context: Hospital
 - Finger/eye scanning system to replace health cards
 - Education for emergency + volunteer room staff on how to properly communicate with people in crisis
 - Public Education about accessing healthcare - prior and on location
+
+{{< backlink "/ideas/co-design-session-1.html" >}}

--- a/content/image-descriptions/co-design-session-2/group-discussion-whiteboard.md
+++ b/content/image-descriptions/co-design-session-2/group-discussion-whiteboard.md
@@ -70,3 +70,5 @@ Theme: Lost & Found
 - people plan where they go {{< arrow >}} how to help when things change
 - culture of city {{< arrow >}} only changing/dynamic in some areas
     - letting other areas know that they may be next to become dynamic
+
+{{< backlink "/ideas/co-design-session-2/index.md" >}}

--- a/content/image-descriptions/co-design-session-2/prototype-discussion-whiteboard.md
+++ b/content/image-descriptions/co-design-session-2/prototype-discussion-whiteboard.md
@@ -110,3 +110,5 @@ Whiteboard of notes on the discussion of the 5 prototypes. Each group described 
         - multiple benefits
     - each doors@building has screen
         - info is on things that don't change
+
+{{< backlink "/ideas/co-design-session-2/index.md" >}}

--- a/content/image-descriptions/co-design-session-3/group-discussion-whiteboard.md
+++ b/content/image-descriptions/co-design-session-3/group-discussion-whiteboard.md
@@ -29,9 +29,9 @@ Whiteboard with ideas generated during a large group discussion.
 * Construction sites{{< arrow >}} hard to get around & never the same {{< arrow >}} no curb cuts
 * Apps for construction zones/closures
 * More audio things {{< arrow >}} where to tap for presto {{< arrow >}} better turnstiles
-* Taxis {{< arrow >}} hard to flag 
+* Taxis {{< arrow >}} hard to flag
   * Cant see meter, only uber has an app
-* More space to sit on sidewalk 
+* More space to sit on sidewalk
   * Not in way to prevent tripping
 
 ## Cats and Dogs group
@@ -55,3 +55,5 @@ Whiteboard with ideas generated during a large group discussion.
 ## Assorted Barrier Busters group
 
 * Cab pulling up to office building in January {{< arrow >}} ramp and road clear of debris {{< arrow >}} some vehicle that docks at cab for smooth transition/transfer which carries you into building {{< arrow >}} recall your accessibility preferences based on badge {{< arrow >}} app to be a local helper.
+
+{{< backlink "/ideas/co-design-session-3/index.md" >}}

--- a/content/image-descriptions/co-design-session-3/prototype-discussion-whiteboard.md
+++ b/content/image-descriptions/co-design-session-3/prototype-discussion-whiteboard.md
@@ -17,12 +17,12 @@ Whiteboard of notes on the discussion of the 5 prototypes. Each group described 
 
 * Warning plate {{< arrow >}} warn people that a ramp/drop is approaching
 * Constructed like an ice cream sandwich
-  * Cane users can hear that they’re on it 
-* Haptic features {{< arrow >}} circuitry inside and underneath 
+  * Cane users can hear that they’re on it
+* Haptic features {{< arrow >}} circuitry inside and underneath
 * Heating plate
 * How many lights? {{< arrow >}} solicit user feedback
 * Will heating interfere with other circuitry
-* Navigate to plate {{< arrow >}} meant to indicate upcoming slope {{< arrow >}} plate at top of slope {{< arrow >}} find feel with tactility of bumps 
+* Navigate to plate {{< arrow >}} meant to indicate upcoming slope {{< arrow >}} plate at top of slope {{< arrow >}} find feel with tactility of bumps
   * Metal because of durability and conductivity
 
 ### Criticisms
@@ -37,7 +37,7 @@ Whiteboard of notes on the discussion of the 5 prototypes. Each group described 
 * Holes for heating/drainage/light {{< arrow >}} hole are very small
 * Hollow space changes sound regardless how you navigate
 * Bumps are like current tactile bumps but smoothed out a little for smoother movement for all
-	
+
 ## Cats and Dogs group
 
 * Wayfinding to get to building
@@ -58,7 +58,7 @@ Whiteboard of notes on the discussion of the 5 prototypes. Each group described 
 * Has auditory output
 * Doesn’t require personal info {{< arrow >}} just preferences
 * Stored on site {{< arrow >}} connected to larger system (about 3 ft tall to prevent tripping and easier use)
-* Battery powered 
+* Battery powered
 * Has emergency mode and leads to nearest exit
 * How not to freak out pets {{< arrow >}} if it becomes common you can train it to become used to it
 * Automation eventually leads to savings
@@ -74,7 +74,7 @@ Whiteboard of notes on the discussion of the 5 prototypes. Each group described 
 * Open source real time data
 * Personal profile that you can access at bus stop if your phone dies/you don’t have a phone
 * 1st screen {{< arrow >}} location and destination {{< arrow >}} mode of transport
-* Give other info {{< arrow >}} interests, hobbies, good snow removal, construction (detailed information), fallen trees, links to things (311/911) 
+* Give other info {{< arrow >}} interests, hobbies, good snow removal, construction (detailed information), fallen trees, links to things (311/911)
 * “In-Struct”
 
 ### Revisions/Discussion
@@ -83,7 +83,7 @@ Whiteboard of notes on the discussion of the 5 prototypes. Each group described 
 * If phone dies {{< arrow >}} charging stations which has all the ports
 * Multimodal notifications {{< arrow >}} multilingual
 * Problems with wifi and data costs money
-* Keep simple and easy to use 
+* Keep simple and easy to use
   * Focus on GPS aspect
   * Curb cuts and construction
 * Kiosk {{< arrow >}} find info and charge device
@@ -103,14 +103,14 @@ Whiteboard of notes on the discussion of the 5 prototypes. Each group described 
 ### Revision/Discussion
 
 * No physical barriers {{< arrow >}} was intentional, trying not to exclude people, system meant to draw attention to be wary of people crossing, should be pedestrians only
-* What happens when elevator is broken 
+* What happens when elevator is broken
   * Info will be in embedded app
 * How to scale? {{< arrow >}} network of paths?
 * What about snow? {{< arrow >}} robots or heated
 
 ## Assorted Barrier Busters group
 
-* Interview next day 
+* Interview next day
 * Access app for accessibility in and out of buildings
 * Voice activation
 * Set up for automation at thresholds
@@ -121,7 +121,7 @@ Whiteboard of notes on the discussion of the 5 prototypes. Each group described 
   * Control panels on the side (not on door side)
   * Height accessible buttons
   * Buttons raised and have braille
-* Display outside elevator to tell which one is coming and how long 
+* Display outside elevator to tell which one is coming and how long
   * Beeps a few seconds before it arrives
 
 ### Revision/Discussion
@@ -130,4 +130,6 @@ Whiteboard of notes on the discussion of the 5 prototypes. Each group described 
 * Smartphone/app {{< arrow >}} fob with 3 buttons and the ability to pre-set custom preferences
 * New system {{< arrow >}} learning curve? Building costs?
 * Employer gives people phones
-* Like the idea of buttons on side instead of on door 
+* Like the idea of buttons on side instead of on door
+
+{{< backlink "/ideas/co-design-session-3/index.md" >}}

--- a/layouts/shortcodes/backlink.html
+++ b/layouts/shortcodes/backlink.html
@@ -1,0 +1,1 @@
+<p><a href="{{ relref . (.Get 0) }}">Back to {{ with .Site.GetPage (.Get 0) }}{{ .Title }}{{ end }}</a></p>


### PR DESCRIPTION
Introduce a new shortcode "backlink" and use it to add backlinks to the image description pages. Also update the Hackathon PRDs to use the new shortcode.

https://issues.fluidproject.org/browse/CITY-27
