### PR TITLE
feat: remove sign up button and link to archived mailing list

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -37,7 +37,6 @@
 
 <div id="mailingListContainer">
     <div class="mailingList"><h2>Get Involved</h2>
-        <p>We are interested in learning more about connected communities and exploring ways to make them more inclusive, flexible and welcoming for diverse needs and perspectives. Please <a href="mailto:cities@idrc.ocadu.ca">email us</a> or <a href="https://lists.inclusivedesign.ca/mailman/listinfo/cities">join our discussion list</a> if you’d like to be part of this conversation. </p>
-        <p><a class="submit" href="https://lists.inclusivedesign.ca/mailman/listinfo/cities">Sign up</a></p>
+        <p>We are interested in learning more about connected communities and exploring ways to make them more inclusive, flexible and welcoming for diverse needs and perspectives. Please <a href="mailto:cities@idrc.ocadu.ca">email us</a> if you’d like to be part of this conversation. </p>
     </div>
 </div>


### PR DESCRIPTION
Remove sign up button and link to archived mailing list in get involved section of the home page.